### PR TITLE
Add admin to WasmMsg::Instantiate

### DIFF
--- a/packages/std/src/results/cosmos_msg.rs
+++ b/packages/std/src/results/cosmos_msg.rs
@@ -156,6 +156,7 @@ pub enum WasmMsg {
     /// This is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.16.0-alpha1/x/wasm/internal/types/tx.proto#L47-L61).
     /// `sender` is automatically filled with the current contract's address.
     Instantiate {
+        admin: Option<String>,
         code_id: u64,
         /// code_hash is the hex encoded hash of the code. This is used by Secret Network to harden against replaying the contract
         /// It is used to bind the request to a destination contract in a stronger way than just the contract address which can be faked
@@ -215,7 +216,10 @@ pub enum VoteOption {
     NoWithVeto,
 }
 
+
 /// Shortcut helper as the construction of WasmMsg::Instantiate can be quite verbose in contract code.
+///
+/// When using this, `admin` is always unset. If you need more flexibility, create the message directly.
 pub fn wasm_instantiate(
     code_id: u64,
     code_hash: impl Into<String>,
@@ -225,6 +229,7 @@ pub fn wasm_instantiate(
 ) -> StdResult<WasmMsg> {
     let payload = to_binary(msg)?;
     Ok(WasmMsg::Instantiate {
+        admin: None,
         code_id,
         code_hash: code_hash.into(),
         msg: payload,

--- a/packages/std/src/testing/mock.rs
+++ b/packages/std/src/testing/mock.rs
@@ -253,7 +253,7 @@ pub fn mock_env() -> Env {
                 Binary::from_base64("wLsKdf/sYqvSMI0G0aWRjob25mrIB0VQVjTjDXnDafk=").unwrap(),
             ),
         },
-        transaction: Some(TransactionInfo { index: 3, hash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" }),
+        transaction: Some(TransactionInfo { index: 3, hash: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string() }),
         contract: ContractInfo {
             address: Addr::unchecked(MOCK_CONTRACT_ADDR),
             code_hash: "".to_string(),


### PR DESCRIPTION
Copied to match upstream:
https://github.com/CosmWasm/cosmwasm/blob/09555ac1295f1f9129fd1fa5139d19763d16d2a1/packages/std/src/results/cosmos_msg.rs#L159C8-L159C8

Also, fixes fixes setting mock_env hash.

However, I am testing it out in my example contract, and setting admin from rust does not appear to be working. Is there maybe some reason the admin param wouldn't be read automatically on the GO side? ... It very well could be a mistake on my side, I'm still testing it out.

here's where I'm setting it for reference:
https://github.com/eqoty-labs/snip721-migratable/blob/aea67604348f29d779172abb803cf6e0cee5f52e/contracts/snip721-dealer/src/contract.rs#L77